### PR TITLE
Rubocop modification

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,9 @@ Metrics/ClassLength:
 Style/ParallelAssignment:
   Enabled: false
 
+Style/CommentedKeyword:
+  Enabled: false
+
 Style/DoubleNegation:
   Enabled: false
 

--- a/lib/rubyplot.rb
+++ b/lib/rubyplot.rb
@@ -17,7 +17,7 @@ require 'rubyplot/gr_wrapper'
 module Rubyplot
   def self.backend
     b = ENV['RUBYPLOT_BACKEND']
-    return b.to_sym if %w[magick ].include?(b)
+    return b.to_sym if %w[magick].include?(b)
 
     :magick
   end

--- a/lib/rubyplot/artist/axes.rb
+++ b/lib/rubyplot/artist/axes.rb
@@ -275,9 +275,7 @@ module Rubyplot
         @texts << Rubyplot::Artist::Text.new(
           @title, self, abs_x: abs_x + width / 2, abs_y: abs_y + @title_margin,
           font: @font, color: @font_color,
-          pointsize: @title_font_size, internal_label: 'axes title.'
-
-        )
+          pointsize: @title_font_size, internal_label: 'axes title.')
       end
 
       def calculate_xy_axes_origin
@@ -348,9 +346,6 @@ module Rubyplot
         @y_axis.min_val = @y_range[0]
         @y_axis.max_val = @y_range[1]
       end
-    end
-    # class Axes
-  end
-  # moudle Artist
-end
-# module Rubyplot
+    end # class Axes
+  end # moudle Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/axis/base.rb
+++ b/lib/rubyplot/artist/axis/base.rb
@@ -23,18 +23,13 @@ module Rubyplot
           @lines = []
         end
 
-
         def draw
           configure_title
           @lines.each(&:draw)
           @texts.each(&:draw)
         end
 
-      end
-      # class Base
-    end
-    # class Axis
-  end
-  # class Artist
-end
-# module Rubyplot
+      end # class Base
+    end # class Axis
+  end # class Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/axis/x_axis.rb
+++ b/lib/rubyplot/artist/axis/x_axis.rb
@@ -11,7 +11,7 @@ module Rubyplot
         @length = (@abs_x2 - @abs_x1).abs
         configure_axis_line
       end
-      
+
       private
 
       def configure_axis_line
@@ -30,9 +30,6 @@ module Rubyplot
           abs_x: @axes.origin[0] + (@abs_x2 - @abs_x1)/2
         )
       end
-    end
-    # class XAxis
-  end
-  # class Artist
-end
-# module Rubyplot
+    end # class XAxis
+  end # class Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/axis/y_axis.rb
+++ b/lib/rubyplot/artist/axis/y_axis.rb
@@ -35,9 +35,6 @@ module Rubyplot
           pointsize: @axes.marker_font_size
         )
       end
-    end
-    # class YAxis
-  end
-  # class Artist
-end
-# module Rubyplot
+    end # class YAxis
+  end # class Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/base.rb
+++ b/lib/rubyplot/artist/base.rb
@@ -12,9 +12,6 @@ module Rubyplot
         @abs_x = abs_x
         @abs_y = abs_y
       end
-    end
-    # class Base
-  end
-  # module Artist
-end
-# module Rubyplot
+    end # class Base
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/circle.rb
+++ b/lib/rubyplot/artist/circle.rb
@@ -23,9 +23,6 @@ module Rubyplot
           color: Rubyplot::Color::COLOR_INDEX[@color]
         )
       end
-    end
-    # class Circle
-  end
-  # module Artist
-end
-# module Rubyplot
+    end # class Circle
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/figure.rb
+++ b/lib/rubyplot/artist/figure.rb
@@ -84,9 +84,6 @@ module Rubyplot
         @marker_color = @theme_options[:marker_color]
         @font_color = @theme_options[:font_color] || @marker_color
       end
-    end
-    # class Figure
-  end
-  # module Artist
-end
-# module Rubyplot
+    end # class Figure
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/legend.rb
+++ b/lib/rubyplot/artist/legend.rb
@@ -54,9 +54,6 @@ module Rubyplot
           pointsize: @font_size
         )
       end
-    end
-    # class Legend
-  end
-  # class Artist
-end
-# module Rubyplot
+    end # class Legend
+  end # class Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/legend_box.rb
+++ b/lib/rubyplot/artist/legend_box.rb
@@ -84,9 +84,6 @@ module Rubyplot
           )
         end
       end
-    end
-    # class LegendBox
-  end
-  # module Artist
-end
-# module Rubyplot
+    end # class LegendBox
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/line2d.rb
+++ b/lib/rubyplot/artist/line2d.rb
@@ -20,9 +20,6 @@ module Rubyplot
         @backend.draw_line(x1: @abs_x1, y1: @abs_y1, x2: @abs_x2, y2: @abs_y2,
                            stroke_width: @stroke_width)
       end
-    end
-    # class Line2D
-  end
-  # class Artist
-end
-# module Rubyplot
+    end # class Line2D
+  end # class Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/plot/area.rb
+++ b/lib/rubyplot/artist/plot/area.rb
@@ -3,7 +3,7 @@ module Rubyplot
     module Plot
       class Area < Artist::Plot::Base
         attr_accessor :sorted_data
-        
+
         def initialize(*)
           super
           @sorted_data = true
@@ -32,11 +32,7 @@ module Rubyplot
             fill_opacity: 0.3
           ).draw
         end
-      end
-      # class Area
-    end
-    # module Plot
-  end
-  # module Artist
-end
-# module Rubyplot
+      end # class Area
+    end # module Plot
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/plot/bar.rb
+++ b/lib/rubyplot/artist/plot/bar.rb
@@ -63,11 +63,7 @@ module Rubyplot
             )
           end
         end
-      end
-      # class Bar
-    end
-    # module Plot
-  end
-  # module Artist
-end
-# module Rubyplot
+      end # class Bar
+    end # module Plot
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/plot/bar_type.rb
+++ b/lib/rubyplot/artist/plot/bar_type.rb
@@ -25,11 +25,7 @@ module Rubyplot
 
         protected
 
-      end
-      # class BarType
-    end
-    # module Plot
-  end
-  # module Artist
-end
-# module Rubyplot
+      end # class BarType
+    end # module Plot
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/plot/base.rb
+++ b/lib/rubyplot/artist/plot/base.rb
@@ -62,11 +62,7 @@ module Rubyplot
             end
           end
         end
-      end
-      # class Base
-    end
-    # module Plot
-  end
-  # module Artist
-end
-# module Rubyplot
+      end # class Base
+    end # module Plot
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/plot/bubble.rb
+++ b/lib/rubyplot/artist/plot/bubble.rb
@@ -35,11 +35,7 @@ module Rubyplot
           end
           @bubbles.each(&:draw)
         end
-      end
-      # class Bubble
-    end
-    # module Plot
-  end
-  # module Artist
-end
-# module Rubyplot
+      end # class Bubble
+    end # module Plot
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/plot/line.rb
+++ b/lib/rubyplot/artist/plot/line.rb
@@ -55,11 +55,7 @@ module Rubyplot
             prev_y = new_y
           end
         end
-      end
-      # class Line
-    end
-    # module Plot
-  end
-  # module Artist
-end
-# module Rubyplot
+      end # class Line
+    end # module Plot
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/plot/multi_bars.rb
+++ b/lib/rubyplot/artist/plot/multi_bars.rb
@@ -69,11 +69,7 @@ module Rubyplot
             bar_plot.abs_y_left[i] = @axes.origin[1] - @axes.x_axis.stroke_width
           end
         end
-      end
-      # class MultiBars
-    end
-    # module Plot
-  end
-  # module Artist
-end
-# module Rubyplot
+      end # class MultiBars
+    end # module Plot
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/plot/multi_stacked_bar.rb
+++ b/lib/rubyplot/artist/plot/multi_stacked_bar.rb
@@ -72,11 +72,7 @@ module Rubyplot
             bar.abs_y_left[i] = (@axes.abs_y + @axes.y_axis.length) - pedestal_height
           end
         end
-      end
-      # class StackedBar
-    end
-    # module Plot
-  end
-  # module Artist
-end
-# module Rubyplot
+      end # class StackedBar
+    end # module Plot
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/plot/scatter.rb
+++ b/lib/rubyplot/artist/plot/scatter.rb
@@ -23,11 +23,7 @@ module Rubyplot
             ).draw
           end
         end
-      end
-      # class Scatter
-    end
-    # module Plot
-  end
-  # module Artist
-end
-# module Rubyplot
+      end # class Scatter
+    end # module Plot
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/plot/stacked_bar.rb
+++ b/lib/rubyplot/artist/plot/stacked_bar.rb
@@ -63,11 +63,7 @@ module Rubyplot
             )
           end
         end
-      end
-      # class StackedBar
-    end
-    # module Plot
-  end
-  # module Artist
-end
-# module Rubyplot
+      end # class StackedBar
+    end # module Plot
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/polygon.rb
+++ b/lib/rubyplot/artist/polygon.rb
@@ -17,9 +17,6 @@ module Rubyplot
           fill_opacity: @fill_opacity
         )
       end
-    end
-    # class Polygon
-  end
-  # module Artist
-end
-# module Rubyplot
+    end # class Polygon
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/rectangle.rb
+++ b/lib/rubyplot/artist/rectangle.rb
@@ -34,9 +34,6 @@ module Rubyplot
           fill_color: @fill_color
         )
       end
-    end
-    # class Rectangle
-  end
-  # class Artist
-end
-# moduel Rubyplot
+    end # class Rectangle
+  end # class Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/text.rb
+++ b/lib/rubyplot/artist/text.rb
@@ -47,9 +47,6 @@ module Rubyplot
           rotation: @rotation
         )
       end
-    end
-    # class Text
-  end
-  # class Artist
-end
-# module Rubyplot
+    end # class Text
+  end # class Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/tick/base.rb
+++ b/lib/rubyplot/artist/tick/base.rb
@@ -29,11 +29,7 @@ module Rubyplot
           @tick_width = tick_width
         end
         # rubocop:enable Metrics/ParameterLists
-      end
-      # class Base
-    end
-    # class Tick
-  end
-  # class Artist
-end
-# module Rubyplot
+      end # class Base
+    end # class Tick
+  end # class Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/tick/x_tick.rb
+++ b/lib/rubyplot/artist/tick/x_tick.rb
@@ -20,9 +20,6 @@ module Rubyplot
         )
         @label.draw
       end
-    end
-    # class XTick
-  end
-  # class Artist
-end
-# module Rubyplot
+    end # class XTick
+  end # class Artist
+end # module Rubyplot

--- a/lib/rubyplot/artist/tick/y_tick.rb
+++ b/lib/rubyplot/artist/tick/y_tick.rb
@@ -19,9 +19,6 @@ module Rubyplot
           stroke_width: @tick_width)
         @label.draw
       end
-    end
-    # class YTick
-  end
-  # module Artist
-end
-# module Rubyplot
+    end # class YTick
+  end # module Artist
+end # module Rubyplot

--- a/lib/rubyplot/backend/magick_wrapper.rb
+++ b/lib/rubyplot/backend/magick_wrapper.rb
@@ -16,10 +16,9 @@ module Rubyplot
         @draw = Magick::Draw.new
       end
 
-
-
       # Height in pixels of particular text.
       # @param text [String] Text to be measured.
+
       def text_height(text, font, font_size)
         @draw.pointsize = font_size
         @draw.font = font if font
@@ -138,9 +137,6 @@ module Rubyplot
                         end
         Image.new(width, height, gradient_fill)
       end
-    end
-    # class MagickWrapper
-  end
-  # module Backend
-end
-# module Rubyplot
+    end # class MagickWrapper
+  end # module Backend
+end # module Rubyplot

--- a/lib/rubyplot/gr_wrapper/plot/base_plot/robust_base.rb
+++ b/lib/rubyplot/gr_wrapper/plot/base_plot/robust_base.rb
@@ -71,9 +71,6 @@ module Rubyplot
           end
         end
       end
-    end
-    # module Plot
-  end
-  # module GRWrapper
-end
-# module Rubyplot
+    end # module Plot
+  end # module GRWrapper
+end # module Rubyplot

--- a/lib/rubyplot/gr_wrapper/plot/scatter.rb
+++ b/lib/rubyplot/gr_wrapper/plot/scatter.rb
@@ -46,11 +46,7 @@ module Rubyplot
 
           @tasks.each(&:call)
         end
-      end
-      # class Scatter
-    end
-    # module Plot
-  end
-  # module GRWrapper
-end
-# module Rubyplot
+      end # class Scatter
+    end # module Plot
+  end # module GRWrapper
+end # module Rubyplot

--- a/lib/rubyplot/gr_wrapper/tasks.rb
+++ b/lib/rubyplot/gr_wrapper/tasks.rb
@@ -406,9 +406,6 @@ module Rubyplot
         pattern: 2,
         hatch: 3
       }.freeze
-    end
-    # module Tasks
-  end
-  # module GRWrapper
-end
-# module Rubyplot
+    end # module Tasks
+  end # module GRWrapper
+end # module Rubyplot

--- a/lib/rubyplot/utils.rb
+++ b/lib/rubyplot/utils.rb
@@ -10,7 +10,5 @@ module Rubyplot
         end
       end
     end
-  end
-  # module Utils
-end
-# module Rubyplot
+  end # module Utils
+end # module Rubyplot


### PR DESCRIPTION
@v0dro 
A modification to the rubocop that allows comments after `end` instead of next line. All the changes are made into latest master.
PR #31 is closed.
Please review.