### PR TITLE
Use the environment variable GRDIR for installation

### DIFF
--- a/ext/grruby/extconf.rb
+++ b/ext/grruby/extconf.rb
@@ -1,6 +1,8 @@
 require 'mkmf'
 
-$CFLAGS << ' -I/home/sameer/Downloads/gr/include '
-$LDFLAGS << ' -L/home/sameer/Downloads/gr/lib -lGR -lm -Wl,-rpath,/home/sameer/Downloads/gr/lib '
+GRDIR = ENV["GRDIR"] ||  '/usr/local/gr'
+
+$CFLAGS << " -I#{GRDIR}/include "
+$LDFLAGS << " -L#{GRDIR}/lib -lGR -lm -Wl,-rpath,#{GRDIR}/lib "
 
 create_makefile('grruby/grruby')


### PR DESCRIPTION
This saves you from having to rewrite `ext/grruby/extconf.rb`.